### PR TITLE
ZExt\Datagate\Criteria: conjunction for mongo`s selector

### DIFF
--- a/library/ZExt/Datagate/Criteria/MongoCriteria.php
+++ b/library/ZExt/Datagate/Criteria/MongoCriteria.php
@@ -244,7 +244,7 @@ class MongoCriteria implements CriteriaInterface {
 	 * 
 	 * @param  string $condition
 	 * @param  mixed  $value
-	 * @param  string $type
+	 * @param  string | null $type
 	 * @return MongoCriteria
 	 */
 	public function where($condition, $value = null, $type = null) {


### PR DESCRIPTION
```
$select->where('age >= ?', 18);
$select->where('age <= ?', 25);
```
the first condition will be rewritten, in this version you can combine multiple conditions:
```
$select->where('age >= 18 && age <= 25');

```